### PR TITLE
Do not use off-spec value for end_of_line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,10 +18,6 @@ continuation_indent = 4
 # this option decides when to chopdown the code
 max_line_length = 120
 
-# optional crlf/lf/cr/auto, if it is 'auto', in windows it is crlf other platforms are lf
-# in neovim the value 'auto' is not a valid option, please use 'unset' 
-end_of_line = auto
-
 #optional keep/never/always/smart
 trailing_table_separator = keep
 


### PR DESCRIPTION
The [EditorConfig specification](https://spec.editorconfig.org/#supported-pairs) does not support "auto" as a value for "end_of_line". EditorConfig implementations which adhere to the specification (such as Neovim) will either ignore this value or, worse, show a warning or error to the user. Simply omitting `end_of_line` will use the default end of line value for the platform.

Git (and other source control tools) can handle translating end of line characters between Windows and Unix platforms. The `end_of_line` option is there _only_ when you want to maintain a strict end of line character *across* platforms.